### PR TITLE
[FM-3676] Don't pin requests version exactly

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests==2.2.1
+requests>=2.2.1,<2.7


### PR DESCRIPTION
Requests version pin causes Genesis's `setup.py` to fail (it uses several libs, like AWS SDK which specify a higher version). Most of the libs uses the same upper limit, so I thought it might worth using it (although it's only something that came out of my crystal ball).
